### PR TITLE
Update appveyor.yml

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,6 +13,15 @@ environment:
       BITS: 64
 
 install:
+  # If a newer build is queued for the same PR, cancel this one.
+  # The AppVeyor 'rollout builds' option is supposed to serve the same
+  # purpose, but it is problematic because it tends to cancel builds pushed
+  # directly to main/master instead of just PR builds (or the converse).
+  # credits: JuliaLang developers.
+  - ps: if ($env:APPVEYOR_PULL_REQUEST_NUMBER -and $env:APPVEYOR_BUILD_NUMBER -ne ((Invoke-RestMethod `
+          https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG/history?recordsNumber=50).builds | `
+          Where-Object pullRequestId -eq $env:APPVEYOR_PULL_REQUEST_NUMBER)[0].buildNumber) { `
+            throw "There are newer queued builds for this pull request, failing early." }
   - curl -sSf -o rustup-init.exe https://win.rustup.rs/
   - rustup-init.exe -y --default-toolchain=stable-%TARGET%
   - set PATH=%PATH%;C:\Users\appveyor\.cargo\bin


### PR DESCRIPTION
If a newer build is queued for the same PR, cancel this one.
 The AppVeyor 'rollout builds' option is supposed to serve the same purpose, but it is problematic because it tends to cancel builds pushed directly to main/master instead of just PR builds (or the converse). 

Credits: JuliaLang developers.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI
> [!NOTE]
> This feature is in early access. You can enable or disable it in the [Korbit Console](https://app.korbit.ai/23a4dc05-fc49-49db-bcd6-68b2dff127e6/settings).

### What change is being made?
Add a script to `appveyor.yml` to cancel older builds if a newer build is queued for the same pull request.

### Why are these changes being made?
This change ensures that only the latest build for a pull request is processed, reducing unnecessary resource usage and build times. The AppVeyor &#x27;rollout builds&#x27; option was found to be unreliable, prompting this custom solution inspired by the JuliaLang developers.

<!-- Korbit AI PR Description End -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved build management by preventing conflicts when newer builds are queued for the same pull request.
	- Enhanced reliability of build processing in AppVeyor, particularly for direct pushes to main or master branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->